### PR TITLE
DMD 2.066, GDC 4.9.1 compatibility and minor fixes / imporvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ docs
 *.lib
 *.exe
 dub.userprefs
+*.a

--- a/cl4d/buffer.d
+++ b/cl4d/buffer.d
@@ -45,16 +45,18 @@ struct CLBuffer
 	{
 		// call "base constructor"
 		cl_errcode res;
-		this(clCreateBuffer(context.cptr, flags, datasize, hostptr, &res));
-		
+		auto obj = clCreateBuffer(context.cptr, flags, datasize, hostptr, &res);
+
 		mixin(exceptionHandling(
-			["CL_INVALID_CONTEXT",				""],
-			["CL_INVALID_BUFFER_SIZE",			"hostbuf is empty"],
-			["CL_INVALID_HOST_PTR",				"hostbuf is null and CL_MEM_USE_HOST_PTR or CL_MEM_COPY_HOST_PTR are set in flags or hostbuf !is null but CL_MEM_COPY_HOST_PTR or CL_MEM_USE_HOST_PTR are not set in flags"],
-			["CL_MEM_OBJECT_ALLOCATION_FAILURE",""],
-			["CL_OUT_OF_RESOURCES",				""],
-			["CL_OUT_OF_HOST_MEMORY",			""]
-		));
+								["CL_INVALID_CONTEXT",				""],
+								["CL_INVALID_BUFFER_SIZE",			"hostbuf is empty"],
+								["CL_INVALID_HOST_PTR",				"hostbuf is null and CL_MEM_USE_HOST_PTR or CL_MEM_COPY_HOST_PTR are set in flags or hostbuf !is null but CL_MEM_COPY_HOST_PTR or CL_MEM_USE_HOST_PTR are not set in flags"],
+								["CL_MEM_OBJECT_ALLOCATION_FAILURE",""],
+								["CL_OUT_OF_RESOURCES",				""],
+								["CL_OUT_OF_HOST_MEMORY",			""]
+								));
+
+		this(obj);
 	}
 
 	version(CL_VERSION_1_1)

--- a/cl4d/c/cl.d
+++ b/cl4d/c/cl.d
@@ -29,7 +29,7 @@ package string bringToCurrentScope(alias EnumType)()
 
 extern(System):
 
-alias const(void*)
+alias void*
 	cl_platform_id,
 	cl_device_id,
 	cl_context,

--- a/cl4d/c/cl_platform.d
+++ b/cl4d/c/cl_platform.d
@@ -17,36 +17,18 @@ module cl4d.c.cl_platform;
 // TODO: on MacOSX API calls are __attribute__((weak_import))
 
 // scalar types, leave as aliases for template instantiation
-version(GNU)
-{
-	alias byte		cl_char;
-	alias ubyte		cl_uchar;
-	pragma(attribute, aligned(2)) alias short	cl_short;
-	pragma(attribute, aligned(2)) alias ushort	cl_ushort;
-	pragma(attribute, aligned(4)) alias int		cl_int;
-	pragma(attribute, aligned(4)) alias uint	cl_uint;
-	pragma(attribute, aligned(8)) alias long	cl_long;
-	pragma(attribute, aligned(8)) alias ulong	cl_ulong;
-	
-	pragma(attribute, aligned(2)) alias ushort	cl_half;
-	pragma(attribute, aligned(4)) alias float	cl_float;
-	pragma(attribute, aligned(8)) alias double	cl_double;
-}
-else
-{
-	alias byte		cl_char;
-	alias ubyte		cl_uchar;
-	alias short		cl_short;
-	alias ushort	cl_ushort;
-	alias int		cl_int;
-	alias uint		cl_uint;
-	alias long		cl_long;
-	alias ulong		cl_ulong;
-	
-	alias ushort	cl_half;
-	alias float		cl_float;
-	alias double	cl_double;
-}
+alias byte		cl_char;
+alias ubyte		cl_uchar;
+alias short		cl_short;
+alias ushort	cl_ushort;
+alias int		cl_int;
+alias uint		cl_uint;
+alias long		cl_long;
+alias ulong		cl_ulong;
+
+alias ushort	cl_half;
+alias float		cl_float;
+alias double	cl_double;
 
 /+
 // Macro names and corresponding values defined by OpenCL
@@ -168,14 +150,11 @@ union ` ~ type ~ to!string(size) ~ `
 {
 	`;
     // add aligned attribute if inside GDC
-    version(GNU) res ~= `pragma(attribute, aligned(` ~ to!string(size) ~ ` * ` ~ type ~ `.sizeof)) `;
 	res ~= type ~ "[" ~ to!string(size) ~ `] s;
 	alias s this; // allow array access and implicit conversion to the array
 	struct { ` ~ type ~ ` x, y` ~ (size<=2 ? "" : ", z, w") ~ (size>=16 ? ", __spacer4, __spacer5, __spacer6, __spacer7, __spacer8, __spacer9, sa, sb, sc, sd, se, sf" : "") ~ `; }
 	struct { ` ~ type ~ ` s0, s1` ~ (size<=2 ? "" : ", s2, s3") ~ (size>=8 ? ", s4, s5, s6, s7" : "") ~ (size>=16 ? ", s8, s9, sA, sB, sC, sD, sE, sF" : "") ~ `; }
 	struct { ` ~ type ~ (size>2 ? to!string(size/2) : "") ~ ` lo, hi; }`;
-	version(GNU) res ~= `
-	pragma(attribute, vector_size(` ~ to!string(size) ~ ` * ` ~ type ~ `.sizeof)) ` ~ type ~ " v" ~ to!string(size) ~ `;`;
 	res ~= `
 }
 `;

--- a/cl4d/context.d
+++ b/cl4d/context.d
@@ -84,7 +84,7 @@ public:
 	/**
 	 *	get a list of image formats supported by the OpenCL implementation
 	 */
-	cl_image_format[] supportedImageFormats(cl_mem_flags flags, cl_mem_object_type type) const
+	cl_image_format[] supportedImageFormats(cl_mem_flags flags, cl_mem_object_type type)
 	{
 		cl_uint numFormats;
 		cl_errcode res = clGetSupportedImageFormats(this._object, flags, type, 0, null, &numFormats);

--- a/cl4d/event.d
+++ b/cl4d/event.d
@@ -67,7 +67,7 @@ public:
 	 */
 	void wait() const
 	{
-		cl_errcode res = clWaitForEvents(1, &_handle);
+		cl_errcode res = clWaitForEvents(1, &_object);
 		
 		mixin(exceptionHandling(
 			["CL_INVALID_VALUE",		""],

--- a/cl4d/event.d
+++ b/cl4d/event.d
@@ -67,7 +67,7 @@ public:
 	 */
 	void wait() const
 	{
-		cl_errcode res = clWaitForEvents(1, &_object);
+		cl_errcode res = clWaitForEvents(1, &_handle);
 		
 		mixin(exceptionHandling(
 			["CL_INVALID_VALUE",		""],

--- a/cl4d/image.d
+++ b/cl4d/image.d
@@ -157,7 +157,7 @@ struct CLImage2DGL
 	 *		miplevel= mipmap level to be used
 	 *		texobj	= name of a complete GL 2D, cubemap or rectangle texture object
 	 */
-	this(const CLContext context, cl_mem_flags flags, cl_GLenum target, cl_GLint  miplevel, cl_GLuint texobj)
+	this(CLContext context, cl_mem_flags flags, cl_GLenum target, cl_GLint  miplevel, cl_GLuint texobj)
 	{
 		// call "base constructor"
 		cl_errcode res;
@@ -231,7 +231,7 @@ struct CLImage3DGL
 	 *		miplevel= mipmap level to be used
 	 *		texobj	= name of a complete GL 3D texture object
 	 */
-	this(const CLContext context, cl_mem_flags flags, cl_GLenum target, cl_GLint  miplevel, cl_GLuint texobj)
+	this(CLContext context, cl_mem_flags flags, cl_GLenum target, cl_GLint  miplevel, cl_GLuint texobj)
 	{
 		cl_errcode res;
 		sup = CLImage3D(clCreateFromGLTexture3D(context.cptr, flags, target, miplevel, texobj, &res));

--- a/cl4d/kernel.d
+++ b/cl4d/kernel.d
@@ -130,8 +130,6 @@ public:
 			auto tmp = arg.cptr;
 			setArgx(idx, arg.cptr.sizeof, &tmp);
 		}
-		else static if (is(ArgType : CLObject))
-			static assert(0, "can't set " ~ ArgType.stringof ~ " as a kernel argument!");
 		else static if (is(ArgType == LocalArgSize))
 			setArgx(idx, arg.size, null); // it's a __local parameter, so just set its size
 		else static if (is(ArgType U : U*))

--- a/cl4d/program.d
+++ b/cl4d/program.d
@@ -291,7 +291,7 @@ public:
 		ubyte[][] binaries()
 		{
 			// retrieve sizes of binary data for each device associated with program
-			size_t[] sizes = this.getArrayInfo!(size_t)(CL_PROGRAM_BINARY_SIZES);
+			size_t[] sizes = getBinarySizes();
 
 			// we can't use getArrayInfo for the following
 			// since we need to preallocate the buffers for the binaries
@@ -313,6 +313,25 @@ public:
 			if (res != CL_SUCCESS)
 				throw new CLException(res, "couldn't obtain program binaries");
 
+			return buffer;
+		}
+
+		private size_t[] getBinarySizes() 
+		{
+			assert(_object !is null);
+
+			cl_uint numDevices = this.numDevices();			
+			auto buffer = new size_t[numDevices];
+
+			assert(buffer.length);
+			
+			// get actual data
+			auto res = clGetProgramInfo(_object, CL_PROGRAM_BINARY_SIZES, numDevices * size_t.sizeof, cast(void*)buffer.ptr, null);
+			
+			// error checking
+			if (res != CL_SUCCESS)
+				throw new CLException(res);
+			
 			return buffer;
 		}
 	} // of @property

--- a/cl4d/program.d
+++ b/cl4d/program.d
@@ -104,7 +104,7 @@ public:
 	 * devices or a specific device(s) in the OpenCL context associated with program. OpenCL allows
 	 * program executables to be built using the source or the binary.
 	 */
-	CLProgram build(string options = "", CLDevices devices = CLDevices())
+	void build(string options = "", CLDevices devices = CLDevices())
 	{
 		cl_errcode res;
 		
@@ -134,8 +134,6 @@ public:
 			["CL_COMPILER_NOT_AVAILABLE","program is created with clCreateProgramWithSource and a compiler is not available i.e. CL_DEVICE_COMPILER_AVAILABLE specified in table 4.3 is set to CL_FALSE"],
 			["CL_OUT_OF_HOST_MEMORY",	""]
 		));
-
-		return this;
 	}
 
 	/**

--- a/cl4d/wrapper.d
+++ b/cl4d/wrapper.d
@@ -61,13 +61,13 @@ public:
 	{
 		// increment reference count
 		retain();
-		version(CL4D_VERBOSE) writef("copied %s %X. Reference count is now: %d\n", TName, cast(void*) _object, referenceCount);
+		version(CL4D_VERBOSE) if (_object) writef("copied %s %X. Reference count is now: %d\n", TName, cast(void*) _object, referenceCount);
 	}
 		
 	//! release the object
 	~this()
 	{
-		version(CL4D_VERBOSE) writef("releasing %s %X. Reference count before: %d\n", TName, cast(void*) _object, referenceCount);
+		version(CL4D_VERBOSE) if (_object) writef("releasing %s %X. Reference count before: %d\n", TName, cast(void*) _object, referenceCount);
 		release();
 	}
 
@@ -394,13 +394,18 @@ unittest
 	CLDummy a;
 	CLDummy b;
 	assert(a.referenceCount == 1);
+	assert(b.referenceCount == 1);
 
-	CLDummies c = CLDummies(a, b);
+	CLDummies c = CLDummies(a, b); // Copy to constructor + copy to value
+	assert(c[0].referenceCount == 3);
+	assert(c[1].referenceCount == 3);
+	foreach (ref d; c)
+		assert(d.referenceCount == 3);
 	foreach (d; c)
-		assert(d.referenceCount == 2);
+		assert(d.referenceCount == 4);
 
 	CLDummy d = c[0];
-	assert(d.referenceCount == 3, to!string(d.referenceCount));
+	assert(d.referenceCount == 4, to!string(d.referenceCount));
 
 	uint[5] s = [1,2,3,4,5];
 	CLDummies g = CLDummies(s);

--- a/cl4d/wrapper.d
+++ b/cl4d/wrapper.d
@@ -68,13 +68,10 @@ public:
 		retain();
 		version(CL4D_VERBOSE) writef("copied %s %X. Reference count is now: %d\n", TName, cast(void*) _object, referenceCount);
 	}
-
+		
 	//! release the object
 	~this()
 	{
-		if (_object is null)
-			return;
-
 		version(CL4D_VERBOSE) writef("releasing %s %X. Reference count before: %d\n", TName, cast(void*) _object, referenceCount);
 		release();
 	}
@@ -274,7 +271,7 @@ protected:
 			throw new CLException(res);
 		
 		return buffer;
-	}
+	}	
 	
 	/**
 	 *	special version only used for clGetProgramBuildInfo and clGetKernelWorkgroupInfo

--- a/cl4d/wrapper.d
+++ b/cl4d/wrapper.d
@@ -49,7 +49,7 @@ public:
 	//! this doesn't change the reference count
 	this(T obj)
 	{
-		assert(obj !is null);
+		assert(obj !is null, "Argument 'obj' is null.");
 		_object = obj;
 		version(CL4D_VERBOSE) writef("wrapped %s %X\n", TName, cast(void*) _object);
 	}

--- a/cl4d/wrapper.d
+++ b/cl4d/wrapper.d
@@ -36,7 +36,17 @@ package string CLWrapper(string T, string classInfoFunction)
 {
 	return "private:\nalias " ~ T ~ " T;\n" ~ 
 	"enum TName = \"" ~ T ~ "\";\n" ~ q{
-	package T _object;
+	
+	package void* _handle; // Because T is a const(void*) that prevent the actual structure to be assignable
+	package T _object() const pure nothrow
+	{
+		return cast(T)_handle;
+	}
+	package void _object(T object) nothrow
+	{
+		_handle = cast(void*)object;
+	}
+
 	//public alias _object this; // TODO any merit?
 	package alias T CType; // remember the C type
 

--- a/cl4d/wrapper.d
+++ b/cl4d/wrapper.d
@@ -328,7 +328,7 @@ package struct CLObjectCollection(T)
 	alias _objects this;
 
 	//! takes a list of cl4d CLObjects
-	this(T[] objects)
+	this(T[] objects ...)
 	in
 	{
 		assert(objects !is null);

--- a/dub.json
+++ b/dub.json
@@ -16,6 +16,10 @@
 			"versions": ["CL_VERSION_1_1"]
 		},
 		{
+			"name": "cl4d-verbose",
+			"versions": ["CL_VERSION_1_1", "CL4D_VERBOSE"]
+		},
+		{
 			"name": "vector-example",
 			"sourceFiles": ["vectorAdd.d"],
 			"targetType": "executable",

--- a/dub.json
+++ b/dub.json
@@ -6,6 +6,7 @@
 	"homepage": "https://github.com/Trass3r/cl4d",
 	"license": "BSL-1.0",
 	"sourcePaths": ["cl4d"],
+	"importPaths": ["./"],
 	"dependencies": {
 	},
 	"libs": ["OpenCL"],


### PR DESCRIPTION
I've finished my changes. You can merge them if you want.

DMD 2.066 compatibility, variadic argument syntax
Wrapper structures are assignable, previously const(void*) member prevented this
There wasn't importPath declaration in the dub file, it's added
Verbose configuration added into dub to help upstream modules find leaks
Programs are creatable from binaries
GDC 4.9.1 compatibility
Various fixes and improvements
I have some OpenCL related unit test there: https://github.com/unbornchikken/neuroflow-D

Works well on:

Win/Linux: DMD 2.066, LDC 0.15, GDC 4.9.1
